### PR TITLE
Don't emit a method trace preamble for methods that won't get transformed

### DIFF
--- a/agent/src/main/java/com/octogonapus/omj/agent/Agent.java
+++ b/agent/src/main/java/com/octogonapus/omj/agent/Agent.java
@@ -27,7 +27,9 @@ public final class Agent {
     final DynamicClassDefiner dynamicClassDefiner =
         new DynamicClassDefiner(instrumentation, Util.cacheDir);
 
-    instrumentation.addTransformer(new OMJClassFileTransformer(dynamicClassDefiner));
+    final var classFilter = ClassFilter.Companion.createFromSystemProperties();
+
+    instrumentation.addTransformer(new OMJClassFileTransformer(dynamicClassDefiner, classFilter));
 
     try {
       // Extract the agent-lib jar from our jar and let the instrumented jvm load from it

--- a/agent/src/main/java/com/octogonapus/omj/agent/OMJClassAdapter.java
+++ b/agent/src/main/java/com/octogonapus/omj/agent/OMJClassAdapter.java
@@ -28,6 +28,7 @@ public final class OMJClassAdapter extends ClassVisitor implements Opcodes {
 
   private final Logger logger = LoggerFactory.getLogger(OMJClassAdapter.class);
   private final DynamicClassDefiner dynamicClassDefiner;
+  private final ClassFilter classFilter;
   private int classVersion;
   private String className;
   private String superName;
@@ -35,9 +36,11 @@ public final class OMJClassAdapter extends ClassVisitor implements Opcodes {
   public OMJClassAdapter(
       final int api,
       final ClassVisitor classVisitor,
-      final DynamicClassDefiner dynamicClassDefiner) {
+      final DynamicClassDefiner dynamicClassDefiner,
+      final ClassFilter classFilter) {
     super(api, classVisitor);
     this.dynamicClassDefiner = dynamicClassDefiner;
+    this.classFilter = classFilter;
   }
 
   @Override
@@ -82,22 +85,24 @@ public final class OMJClassAdapter extends ClassVisitor implements Opcodes {
 
     if (isInstanceInitializationMethod(name, descriptor)) {
       return new OMJInstanceInitializationMethodAdapter(
-          api, visitor, dynamicClassDefiner, descriptor, className, superName);
+          api, visitor, dynamicClassDefiner, classFilter, descriptor, className, superName);
     } else if (isClassInitializationMethod(name, descriptor, access)) {
       return new OMJMethodAdapter(
           api,
           visitor,
           dynamicClassDefiner,
+          classFilter,
           descriptor,
           hasAccessFlag(access, ACC_STATIC),
           className);
     } else if (isMainMethod(name, descriptor, access)) {
-      return new OMJMainMethodAdapter(api, visitor, dynamicClassDefiner, className);
+      return new OMJMainMethodAdapter(api, visitor, dynamicClassDefiner, classFilter, className);
     } else {
       return new OMJMethodAdapter(
           api,
           visitor,
           dynamicClassDefiner,
+          classFilter,
           descriptor,
           hasAccessFlag(access, ACC_STATIC),
           className);

--- a/agent/src/main/kotlin/com/octogonapus/omj/agent/ClassFilter.kt
+++ b/agent/src/main/kotlin/com/octogonapus/omj/agent/ClassFilter.kt
@@ -1,0 +1,61 @@
+/*
+ * This file is part of OMJ.
+ *
+ * OMJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OMJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OMJ.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.octogonapus.omj.agent
+
+import java.util.regex.Pattern
+import org.slf4j.LoggerFactory
+
+class ClassFilter private constructor(
+    private val includeFilter: Pattern,
+    private val excludeFilter: Pattern
+) {
+
+    /**
+     * @return True if the class with name [className] should be transformed.
+     */
+    fun shouldTransform(className: String) =
+        includeFilter.matcher(className).matches() &&
+            !excludeFilter.matcher(className).matches()
+
+    companion object {
+
+        private val logger = LoggerFactory.getLogger(ClassFilter::class.java)
+
+        /**
+         * Creates a [ClassFilter] by loading the include and exclude filters from the system
+         * properties `agent.include-package` and `agent.exclude-package`.
+         */
+        fun createFromSystemProperties(): ClassFilter {
+            val includeFilterString = System.getProperty("agent.include-package")
+            val excludeFilterString = System.getProperty("agent.exclude-package")
+            logger.debug("includeFilterString = {}", includeFilterString)
+            logger.debug("excludeFilterString = {}", excludeFilterString)
+
+            checkNotNull(includeFilterString) {
+                "An include filter must be specified with agent.include-package"
+            }
+            checkNotNull(excludeFilterString) {
+                "An exclude filter must be specified with agent.exclude-package"
+            }
+
+            return ClassFilter(
+                Pattern.compile(includeFilterString),
+                Pattern.compile(excludeFilterString)
+            )
+        }
+    }
+}

--- a/agent/src/main/kotlin/com/octogonapus/omj/agent/OMJInstanceInitializationMethodAdapter.kt
+++ b/agent/src/main/kotlin/com/octogonapus/omj/agent/OMJInstanceInitializationMethodAdapter.kt
@@ -27,6 +27,7 @@ internal class OMJInstanceInitializationMethodAdapter(
     api: Int,
     private val superVisitor: MethodVisitor,
     private val dynamicClassDefiner: DynamicClassDefiner,
+    private val classFilter: ClassFilter,
     private val methodDescriptor: String,
     currentClassName: String,
     private val superName: String
@@ -67,13 +68,17 @@ internal class OMJInstanceInitializationMethodAdapter(
             super.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
             superVisitor.recordMethodTrace(methodDescriptor, false, dynamicClassDefiner, logger)
         } else {
-            // Otherwise, this method just contains normal method calls, so emit the typical
-            // preamble.
-            superVisitor.visitMethodCallStartPreamble(
-                currentLineNumber,
-                fullyQualifiedClassName,
-                name
-            )
+            // Only add the preamble to methods which we will also record a trace for
+            if (classFilter.shouldTransform(owner)) {
+                // Otherwise, this method just contains normal method calls, so emit the typical
+                // preamble.
+                superVisitor.visitMethodCallStartPreamble(
+                    currentLineNumber,
+                    fullyQualifiedClassName,
+                    name
+                )
+            }
+
             super.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
         }
     }

--- a/agent/src/main/kotlin/com/octogonapus/omj/agent/OMJMainMethodAdapter.kt
+++ b/agent/src/main/kotlin/com/octogonapus/omj/agent/OMJMainMethodAdapter.kt
@@ -27,6 +27,7 @@ internal class OMJMainMethodAdapter(
     api: Int,
     private val superVisitor: MethodVisitor,
     private val dynamicClassDefiner: DynamicClassDefiner,
+    private val classFilter: ClassFilter,
     currentClassName: String
 ) : MethodVisitor(api, superVisitor), Opcodes {
 
@@ -61,7 +62,15 @@ internal class OMJMainMethodAdapter(
         descriptor: String,
         isInterface: Boolean
     ) {
-        superVisitor.visitMethodCallStartPreamble(currentLineNumber, fullyQualifiedClassName, name)
+        // Only add the preamble to methods which we will also record a trace for
+        if (classFilter.shouldTransform(owner)) {
+            superVisitor.visitMethodCallStartPreamble(
+                currentLineNumber,
+                fullyQualifiedClassName,
+                name
+            )
+        }
+
         super.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
     }
 

--- a/agent/src/main/kotlin/com/octogonapus/omj/agent/OMJMethodAdapter.kt
+++ b/agent/src/main/kotlin/com/octogonapus/omj/agent/OMJMethodAdapter.kt
@@ -27,6 +27,7 @@ internal class OMJMethodAdapter(
     api: Int,
     private val superVisitor: MethodVisitor,
     private val dynamicClassDefiner: DynamicClassDefiner,
+    private val classFilter: ClassFilter,
     private val methodDescriptor: String,
     private val isStatic: Boolean,
     currentClassName: String
@@ -55,7 +56,15 @@ internal class OMJMethodAdapter(
         descriptor: String,
         isInterface: Boolean
     ) {
-        superVisitor.visitMethodCallStartPreamble(currentLineNumber, fullyQualifiedClassName, name)
+        // Only add the preamble to methods which we will also record a trace for
+        if (classFilter.shouldTransform(owner)) {
+            superVisitor.visitMethodCallStartPreamble(
+                currentLineNumber,
+                fullyQualifiedClassName,
+                name
+            )
+        }
+
         super.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
     }
 


### PR DESCRIPTION
### Description of the Change

This PR stops method trace preambles from being emitted unless the method in question will also be transformed.

### Motivation

There is no point in emitting a preamble if its data will never be used because the method the preamble was emitted for is part of a class that won't be transformed.

### Verification Process

This was verified manually.

### Applicable Issues

Closes #16.
