### PR TITLE
Add the JaCoCo agent to subprocess JVMs

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -28,6 +28,7 @@ object Versions {
     const val detektPlugin = "1.9.0"
     const val shadowPlugin = "5.2.0"
     const val javafxPlugin = "0.0.8"
+    const val downloadPlugin = "4.0.4"
 
     const val kotlin = "1.3.72"
     const val ktlint = "0.36.0"

--- a/testUtil/build.gradle.kts
+++ b/testUtil/build.gradle.kts
@@ -13,4 +13,6 @@ dependencies {
     api(group = "io.mockk", name = "mockk", version = Versions.mockk)
 
     api(group = "io.arrow-kt", name = "arrow-core-data", version = Versions.arrow)
+
+    api(group = "org.jacoco", name = "org.jacoco.agent", version = Versions.jacocoTool)
 }

--- a/testUtil/src/main/kotlin/com/octogonapus/omj/testutil/CompileUtil.kt
+++ b/testUtil/src/main/kotlin/com/octogonapus/omj/testutil/CompileUtil.kt
@@ -42,11 +42,13 @@ object CompileUtil {
     }
 
     /**
-     * Runs the agent on a [jarUnderTest] and saves traces into the [traceDir].
+     * Runs the agent on a [jarUnderTest] and saves traces into the [traceDir]. Adds the JaCoCo
+     * agent for coverage information.
      *
      * @param jarUnderTest The filename of the Jar to run under the agent.
      * @param traceDir The dir to save trace files into.
-     * @param debug Whether to start the subprocess JVM for remote debugging.
+     * @param debug Whether to start the subprocess JVM for remote debugging. Adds the JDWP agent
+     * on port 5006.
      */
     fun runAgentTest(
         jarUnderTest: String,
@@ -62,6 +64,15 @@ object CompileUtil {
             "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006"
         ) else emptyList()
 
+        val jacocoJar = System.getProperty("agent-test.jacoco-jar")
+        logger.debug { "jacocoJar=$jacocoJar" }
+
+        val destFile = System.getProperty("agent-test.jacoco-dest-file")
+        logger.debug { "destFile=$destFile" }
+
+        val jacocoArgs = "destfile=$destFile,append=true,inclnolocationclasses=false," +
+            "dumponexit=true,output=file,jmx=false"
+
         val process = ProcessBuilder(
             Paths.get(System.getProperty("java.home"))
                 .resolve("bin")
@@ -73,6 +84,7 @@ object CompileUtil {
             "-Dagent.include-package=com/agenttest/[a-zA-Z0-9/]*",
             "-Dagent.exclude-package=",
             *debugList.toTypedArray(),
+            "-javaagent:$jacocoJar=$jacocoArgs",
             "-javaagent:${System.getProperty("agent.jar")}",
             "-jar",
             jarFile.absolutePath

--- a/testUtil/src/main/kotlin/com/octogonapus/omj/testutil/CompileUtil.kt
+++ b/testUtil/src/main/kotlin/com/octogonapus/omj/testutil/CompileUtil.kt
@@ -73,6 +73,7 @@ object CompileUtil {
         val jacocoArgs = "destfile=$destFile,append=true,inclnolocationclasses=false," +
             "dumponexit=true,output=file,jmx=false"
 
+        @Suppress("SpreadOperator")
         val process = ProcessBuilder(
             Paths.get(System.getProperty("java.home"))
                 .resolve("bin")

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -39,11 +39,16 @@ tasks.test {
 
     val agentAllJarPath = buildDir.toPath().resolve("agent-all").toAbsolutePath()
 
+    // Find the jacoco tool jar that the jacoco plugin uses
+    val jacocoJar = buildDir.walkTopDown().first { it.name == "jacocoagent.jar" }.absolutePath
+
     // The assertion is necessary according to Gradle
     @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
     jvmArgs = jvmArgs!! + listOf(
         "-Dagent-test.jar-dir=" + rootProject.buildDir.toPath().resolve("agent-test-jars"),
-        "-Dagent.jar=$agentAllJarPath"
+        "-Dagent.jar=$agentAllJarPath",
+        "-Dagent-test.jacoco-jar=$jacocoJar",
+        "-Dagent-test.jacoco-dest-file=$buildDir/jacoco/test.exec"
     )
 }
 

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -9,6 +9,13 @@ plugins {
 
 description = "The UI."
 
+// A resolvable configuration to hold dependencies needed by the child JVM (running the agent during
+// integration tests) at runtime.
+val childJVMRuntimeOnly: Configuration by configurations.creating {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+}
+
 dependencies {
     implementation(project(":util"))
     implementation(project(":logging"))
@@ -16,6 +23,12 @@ dependencies {
     runtimeOnly(project(path = ":agent", configuration = "shadow"))
 
     testImplementation(project(":testUtil"))
+
+    childJVMRuntimeOnly(
+        group = "org.jacoco",
+        name = "org.jacoco.agent",
+        version = Versions.jacocoTool
+    )
 }
 
 val agentJarName = "agent-all"
@@ -33,21 +46,32 @@ tasks.named("shadowJar", ShadowJar::class.java) {
     from({ agentJarAllResource })
 }
 
+// JaCoCo stores the agent jar inside the jar they upload to maven, so we need to extract it before
+// we can use it.
+val jacocoAgentJar: Path = buildDir.toPath().resolve("jacocoagent.jar")
+val extractJacocoAgentTask = tasks.register("extractJacocoAgent", Copy::class.java) {
+    from({
+        zipTree(
+            childJVMRuntimeOnly.first {
+                it.name == "org.jacoco.agent-${Versions.jacocoTool}.jar"
+            }
+        ).filter { it.name == "jacocoagent.jar" }.singleFile
+    })
+    into({ buildDir })
+}
+
 tasks.test {
-    dependsOn(copyAgentShadowJarTask)
+    dependsOn(copyAgentShadowJarTask, extractJacocoAgentTask)
     dependsOn(project(":agent-tests").getTasksByName("copyAgentTestJar", true))
 
     val agentAllJarPath = buildDir.toPath().resolve("agent-all").toAbsolutePath()
-
-    // Find the jacoco tool jar that the jacoco plugin uses
-    val jacocoJar = buildDir.walkTopDown().first { it.name == "jacocoagent.jar" }.absolutePath
 
     // The assertion is necessary according to Gradle
     @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
     jvmArgs = jvmArgs!! + listOf(
         "-Dagent-test.jar-dir=" + rootProject.buildDir.toPath().resolve("agent-test-jars"),
         "-Dagent.jar=$agentAllJarPath",
-        "-Dagent-test.jacoco-jar=$jacocoJar",
+        "-Dagent-test.jacoco-jar=$jacocoAgentJar",
         "-Dagent-test.jacoco-dest-file=$buildDir/jacoco/test.exec"
     )
 }


### PR DESCRIPTION
### Description of the Change

This PR adds the JaCoCo agent when starting a subprocess JVM.

### Motivation

This will help us capture code coverage for the integration tests, which start child JVMs.

### Verification Process

Coverage has expectedly gone up a lot, especially for `agent-lib`.

### Applicable Issues

Closes #27.
