### PR TITLE
Downgrade to JDk 11

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="14" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="YAMLSchemaValidation" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_14" default="true" project-jdk-name="14" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/agent/src/main/java/com/octogonapus/omj/agent/DynamicClassDefiner.java
+++ b/agent/src/main/java/com/octogonapus/omj/agent/DynamicClassDefiner.java
@@ -398,7 +398,6 @@ public final class DynamicClassDefiner {
    */
   private void appendFieldValue(final Field field, final StringBuilder builder) {
     final SimpleTypeUtil.SimpleType type = TypeUtil.getSimpleType(field.type);
-    // TODO: Waiting on a new google-java-format release to use enhanced switch statements
     switch (type) {
       case VOID:
         throw new IllegalStateException("Somehow got a field with type void.");

--- a/agent/src/main/java/com/octogonapus/omj/agent/TypeUtil.java
+++ b/agent/src/main/java/com/octogonapus/omj/agent/TypeUtil.java
@@ -72,8 +72,6 @@ final class TypeUtil {
    *     Object}.
    */
   static String getAdaptedClassName(final Type type) {
-    // TODO: Waiting on a new google-java-format release to use enhanced switch statements
-    //noinspection EnhancedSwitchMigration
     switch (type.getSort()) {
       case Type.VOID:
         return "void";
@@ -100,8 +98,6 @@ final class TypeUtil {
 
   /** @return The number of stack slots the type uses. */
   public static int getStackSize(final Type type) {
-    // TODO: Waiting on a new google-java-format release to use enhanced switch statements
-    //noinspection EnhancedSwitchMigration
     switch (type.getSort()) {
       case Type.LONG:
       case Type.DOUBLE:

--- a/agent/src/test/kotlin/com/octogonapus/omj/agent/OMJClassTransformerTest.kt
+++ b/agent/src/test/kotlin/com/octogonapus/omj/agent/OMJClassTransformerTest.kt
@@ -865,7 +865,6 @@ internal class OMJClassTransformerTest : KoinTestFixture() {
                 }
             )
 
-            // TODO: Add tests for new object (not one-liner), finish this test, add test for String
             val methodNode = makeMethodNode(
                 0,
                 methodName,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,15 +25,15 @@ stages:
             restoreKeys: gradle
             path: $(GRADLE_USER_HOME)
 
-        - bash: wget https://cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-linux_x64.tar.gz
+        - bash: wget https://cdn.azul.com/zulu/bin/zulu11.39.15-ca-jdk11.0.7-linux_x64.tar.gz
 
         - task: JavaToolInstaller@0
           inputs:
-            verisonSpec: "14"
+            verisonSpec: "11"
             jdkArchitectureOption: x64
             jdkSourceOption: LocalDirectory
-            jdkFile: "zulu14.28.21-ca-jdk14.0.1-linux_x64.tar.gz"
-            jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk14'
+            jdkFile: "zulu11.39.15-ca-jdk11.0.7-linux_x64.tar.gz"
+            jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk11'
             cleanDestinationDirectory: true
 
         - task: Gradle@2
@@ -78,15 +78,15 @@ stages:
             restoreKeys: gradle
             path: $(GRADLE_USER_HOME)
 
-        - bash: wget https://cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-macosx_x64.tar.gz
+        - bash: wget https://cdn.azul.com/zulu/bin/zulu11.39.15-ca-jdk11.0.7-macosx_x64.tar.gz
 
         - task: JavaToolInstaller@0
           inputs:
-            verisonSpec: "14"
+            verisonSpec: "11"
             jdkArchitectureOption: x64
             jdkSourceOption: LocalDirectory
-            jdkFile: "zulu14.28.21-ca-jdk14.0.1-macosx_x64.tar.gz"
-            jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk14'
+            jdkFile: "zulu11.39.15-ca-jdk11.0.7-macosx_x64.tar.gz"
+            jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk11'
             cleanDestinationDirectory: true
 
         - task: Gradle@2
@@ -120,15 +120,15 @@ stages:
 
       steps:
         # SilentlyContinue is important because it makes the download go WAY faster
-        - powershell: "$ProgressPreference = 'SilentlyContinue'\nInvoke-WebRequest -URI https://cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-win_x64.zip -OutFile zulu14.28.21-ca-jdk14.0.1-win_x64.zip"
+        - powershell: "$ProgressPreference = 'SilentlyContinue'\nInvoke-WebRequest -URI https://cdn.azul.com/zulu/bin/zulu11.39.15-ca-jdk11.0.7-win_x64.zip -OutFile zulu11.39.15-ca-jdk11.0.7-win_x64.zip"
 
         - task: JavaToolInstaller@0
           inputs:
-            verisonSpec: "14"
+            verisonSpec: "11"
             jdkArchitectureOption: x64
             jdkSourceOption: LocalDirectory
-            jdkFile: "zulu14.28.21-ca-jdk14.0.1-win_x64.zip"
-            jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk14'
+            jdkFile: "zulu11.39.15-ca-jdk11.0.7-win_x64.zip"
+            jdkDestinationDirectory: '$(agent.toolsDirectory)/jdk11'
             cleanDestinationDirectory: true
 
         - task: Cache@2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,8 +86,8 @@ subprojects {
     }
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_14
-        targetCompatibility = JavaVersion.VERSION_14
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     tasks.withType<JavaCompile> {

--- a/ui/src/main/java/com/octogonapus/omj/ui/model/TraceIterator.java
+++ b/ui/src/main/java/com/octogonapus/omj/ui/model/TraceIterator.java
@@ -90,8 +90,6 @@ public final class TraceIterator implements Iterator<Trace>, AutoCloseable {
 
     final byte type = parseByte();
 
-    // TODO: Waiting on a new google-java-format release to use enhanced switch statements
-    //noinspection EnhancedSwitchMigration
     switch (type) {
       case 0x1:
         return parseStoreTrace(index);
@@ -288,8 +286,6 @@ public final class TraceIterator implements Iterator<Trace>, AutoCloseable {
    */
   private String parsePrimitiveBytesToString(
       final SimpleTypeUtil.SimpleType type, final byte[] bytes) {
-    // TODO: Waiting on a new google-java-format release to use enhanced switch statements
-    //noinspection EnhancedSwitchMigration
     switch (type) {
       case BOOLEAN:
         return bytes[0] == 0x1 ? "true" : "false";


### PR DESCRIPTION
### Description of the Change

This PR downgrades the target JDK to 11.

### Motivation

JDK 14 was too recent to support many programs. JDK 11, the latest LTS, will have much wider support.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?
-->

### Applicable Issues

Closes #42.
